### PR TITLE
Make the codebase `cargo clippy`-compliant

### DIFF
--- a/src/audio/mp3.rs
+++ b/src/audio/mp3.rs
@@ -3,7 +3,6 @@
 use super::Encoder;
 
 use anyhow::{bail, Context, Result};
-use lame_sys;
 
 /// Error checker for lame_sys functions.
 ///
@@ -25,7 +24,7 @@ fn check_err(num: std::os::raw::c_int) -> Result<std::os::raw::c_int> {
     } else if num == lame_sys::lame_errorcodes_t::FRONTEND_WRITEERROR as i32 {
         bail!("lame: frontend write error");
     } else if num == lame_sys::lame_errorcodes_t::FRONTEND_FILETOOLARGE as i32 {
-        bail!("lame: frontend write error");
+        bail!("lame: frontend file too large");
     } else if num < 0 {
         bail!("lame: unknown error: {}", num);
     }

--- a/src/audio/opus.rs
+++ b/src/audio/opus.rs
@@ -38,7 +38,7 @@ impl OpusEncoder {
             .context("could not get encoder internal delay")? as usize;
 
         Ok(OpusEncoder {
-            enc: enc,
+            enc,
             muxer: WebmStreamMuxer::new(Self::SAMPLE_RATE, channels, internal_delay),
             wrote_initialization_segment: false,
         })
@@ -113,9 +113,9 @@ pub struct WebmStreamMuxer {
 impl WebmStreamMuxer {
     pub fn new(sample_rate: u32, channels: u8, internal_delay: usize) -> WebmStreamMuxer {
         WebmStreamMuxer {
-            sample_rate: sample_rate,
-            channels: channels,
-            internal_delay: internal_delay,
+            sample_rate,
+            channels,
+            internal_delay,
         }
     }
 
@@ -241,7 +241,7 @@ impl WebmStreamMuxer {
             ((codec_delay_ns >> 24) & 0xff) as u8,
             ((codec_delay_ns >> 16) & 0xff) as u8,
             ((codec_delay_ns >> 8) & 0xff) as u8,
-            ((codec_delay_ns >> 0) & 0xff) as u8,
+            (codec_delay_ns & 0xff) as u8,
             0x63,
             0xA2, // CodecPrivate
             0x93, // Size = 19
@@ -255,9 +255,9 @@ impl WebmStreamMuxer {
             0x64, // "OpusHead"
             0x01, // version
             self.channels,
-            ((self.internal_delay >> 0) & 0xff) as u8,
+            (self.internal_delay & 0xff) as u8,
             ((self.internal_delay >> 8) & 0xff) as u8,
-            ((self.sample_rate >> 0) & 0xff) as u8,
+            (self.sample_rate & 0xff) as u8,
             ((self.sample_rate >> 8) & 0xff) as u8,
             ((self.sample_rate >> 16) & 0xff) as u8,
             ((self.sample_rate >> 24) & 0xff) as u8,
@@ -314,7 +314,7 @@ impl StreamMuxer for WebmStreamMuxer {
             ((timestamp >> 24) & 0xFF) as u8,
             ((timestamp >> 16) & 0xFF) as u8,
             ((timestamp >> 8) & 0xFF) as u8,
-            ((timestamp >> 0) & 0xFF) as u8,
+            (timestamp & 0xFF) as u8,
             0xA3, // SimpleBlock
             0x40 | ((simple_block_len) >> 8) as u8,
             (simple_block_len & 0xff) as u8, // size

--- a/src/rfb.rs
+++ b/src/rfb.rs
@@ -161,7 +161,7 @@ impl RfbConnection {
         })
     }
 
-    pub fn split<'a>(&'a mut self) -> (ReadHalf<'a>, WriteHalf<'a>) {
+    pub fn split(&mut self) -> (ReadHalf, WriteHalf) {
         let (rs, ws) = self.stream.split();
         (
             ReadHalf {
@@ -267,7 +267,7 @@ pub struct WriteHalf<'a> {
 }
 
 impl WriteHalf<'_> {
-    pub async fn write_all(&mut self, buf: &Vec<u8>) -> Result<()> {
+    pub async fn write_all(&mut self, buf: &[u8]) -> Result<()> {
         let mut cur = std::io::Cursor::new(&buf[..]);
         loop {
             if cur.remaining() > 0 {
@@ -478,7 +478,7 @@ impl WriteHalf<'_> {
             // in the connection being closed.
             Err(e) => {
                 log::error!("->: !! welp: {:?}", e);
-                Err(e.into())
+                Err(e)
             }
         }
     }


### PR DESCRIPTION
This change makes `cargo clippy` execute cleanly.