### PR TITLE
Fix a couple of panics

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -125,7 +125,7 @@ impl Stream {
             bail!("failed to read PulseAudio data: {}", e);
         }
         self.timestamp = std::cmp::max(
-            self.timestamp + self.enc.frame_len_ms(),
+            self.timestamp.wrapping_add(self.enc.frame_len_ms()),
             self.stream_start
                 .get_or_insert_with(std::time::Instant::now)
                 .elapsed()

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,7 @@ async fn handle_request(
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let matches = clap::App::new("audiomux")
+    let matches = clap::App::new("rfbproxy")
         .about("An RFB proxy that enables WebSockets and audio")
         .arg(
             clap::Arg::with_name("address")

--- a/src/messages/io.rs
+++ b/src/messages/io.rs
@@ -89,7 +89,10 @@ pub fn read<'a>(src: &mut std::io::Cursor<&'a [u8]>, n: usize) -> Result<&'a [u8
         return Err(Error::Incomplete);
     }
 
-    Ok(&src.get_ref()[0..n])
+    let pos = src.position() as usize;
+    let result = &src.get_ref()[pos..pos + n];
+    src.advance(n);
+    Ok(result)
 }
 
 pub fn peek(src: &std::io::Cursor<&[u8]>, n: usize) -> Result<Vec<u8>, Error> {


### PR DESCRIPTION
This change fixes two panics:

a) One that happens because we were overflowing (intentionally) when
   creating the first timestamp of the audio stream, so that the very
   first frame gets timestamp zero. This only panicked in debug mode.
b) `messages::io::read()` assumed that it was always being called in the
   zero position, but this is not really true always.