### PR TITLE
Add functions to validate Goval Handshake v5 tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+base64 = "0.13.0"
 byte-slice-cast = "1.0.0"
 bytes = "1.0.1"
+chrono = "0.4"
 clap = "2.33"
 env_logger = "*"
 futures = "0.3.12"
@@ -18,12 +20,14 @@ hyper-tungstenite = "0.2"
 lame-sys = "0.1.2"
 log = "*"
 opus = "0.2.1"
+paseto = { version = "2.0.1+1.0.3", features = ["v2"] }
 path-clean = "0.1"
 prost = "0.7"
 prost-types = "0.7"
 psimple = { package = "libpulse-simple-binding", version = "2.20.1" }
 pulse = { package = "libpulse-binding", version = "2.20.0" }
 rand = "0.8.2"
+ring = "0.16"
 tokio = { version = "1.2", features = ["full"] }
 tokio-tungstenite = "0.13.0"
 


### PR DESCRIPTION
This change adds `auth::validate_token()`, plus tests.