### PR TITLE
Use the alternate selector when printing errors

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -185,7 +185,7 @@ impl Stream {
             // Always consume the frame from PulseAudio. That way this thread doesn't end up with
             // huge jumps or large number of dropped messages.
             if let Err(e) = self.read_frame() {
-                log::error!("failed to read audio frame: {}", e);
+                log::error!("failed to read audio frame: {:#}", e);
                 break;
             }
             let permit = match audio_message_chan.try_reserve() {
@@ -196,14 +196,14 @@ impl Stream {
                     continue;
                 }
                 Err(e) => {
-                    log::error!("failed to send audio data: {}", e);
+                    log::error!("failed to send audio data: {:#}", e);
                     break;
                 }
             };
             let payload = match self.encode_frame() {
                 Ok(payload) => payload,
                 Err(e) => {
-                    log::error!("failed to read audio frame: {}", e);
+                    log::error!("failed to read audio frame: {:#}", e);
                     break;
                 }
             };

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -197,7 +197,6 @@ where
 
     // All the preamble is done, now receive username+password.
     let (username, password) = client_username_password(ws_stream).await?;
-    log::debug!("->: {:?} {:?}", &username, &password);
 
     match validate_token(&username, &replid, pubkeys).context("token validation") {
         Ok(()) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ where
         while let Some(msg) = rws.next().await {
             if let Ok(Message::Binary(payload)) = msg {
                 if let Err(err) = ws.write_all(&payload).await {
-                    log::error!("failed to write a message to the server: {}", err);
+                    log::error!("failed to write a message to the server: {:#}", err);
                     break;
                 }
             }
@@ -68,12 +68,12 @@ where
                 }
                 Ok(n) => {
                     if let Err(err) = wws.send(Message::Binary((&buffer[..n]).to_vec())).await {
-                        log::error!("failed to write a message to the client: {}", err);
+                        log::error!("failed to write a message to the client: {:#}", err);
                         break;
                     }
                 }
                 Err(err) => {
-                    log::error!("failed to read a message from the server: {}", err);
+                    log::error!("failed to read a message from the server: {:#}", err);
                     break;
                 }
             }
@@ -134,7 +134,7 @@ where
 
             if let Some(payload) = payload {
                 if let Err(err) = ws.write_all(&payload).await {
-                    log::error!("failed to write message: {}", err);
+                    log::error!("failed to write message: {:#}", err);
                     break;
                 }
             }
@@ -229,14 +229,14 @@ async fn handle_request(
             let ws_stream = match websocket.await {
                 Ok(ws_stream) => ws_stream,
                 Err(e) => {
-                    log::error!("error in websocket upgrade: {}", e);
+                    log::error!("error in websocket upgrade: {:#}", e);
                     return;
                 }
             };
             if let Err(e) =
                 handle_connection(rfb_addr, ws_stream, &authentication, enable_audio).await
             {
-                log::error!("error in websocket connection: {}", e);
+                log::error!("error in websocket connection: {:#}", e);
             }
             log::info!("{} disconnected", remote_addr);
         });
@@ -379,7 +379,7 @@ async fn main() -> Result<()> {
                 if let Err(e) =
                     handle_connection(rfb_addr, ws_stream, &authentication, enable_audio).await
                 {
-                    log::error!("error in websocket connection: {}", e);
+                    log::error!("error in websocket connection: {:#}", e);
                 }
                 log::info!("{} disconnected", remote_addr);
             });

--- a/src/rfb.rs
+++ b/src/rfb.rs
@@ -242,7 +242,7 @@ impl WriteHalf<'_> {
                     self.audio_stream = match audio::Stream::new(channels, codec, kbps) {
                         Ok(stream) => Some(stream),
                         Err(e) => {
-                            log::error!("failed to create an audio stream: {}", e);
+                            log::error!("failed to create an audio stream: {:#}", e);
                             self.client_tx
                                 .send(
                                     server::Message::ReplitAudioServerMessage(vec![
@@ -317,7 +317,7 @@ impl WriteHalf<'_> {
                                 )
                                 .await
                             {
-                                log::error!("failed to notify client of audio closure: {}", e);
+                                log::error!("failed to notify client of audio closure: {:#}", e);
                             }
                         });
                     });


### PR DESCRIPTION
This change makes it such that the errors are printed with the full
chain of causality instead of just the last context.