### PR TITLE
Allow authentication with the "runner" username

### DIFF
--- a/src/rfb.rs
+++ b/src/rfb.rs
@@ -186,7 +186,7 @@ pub struct WriteHalf<'a> {
 
 impl WriteHalf<'_> {
     pub async fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        let mut cur = std::io::Cursor::new(&buf[..]);
+        let mut cur = std::io::Cursor::new(buf);
         loop {
             if cur.remaining() > 0 {
                 if self.buf.capacity() - self.buf.len() < cur.remaining() {


### PR DESCRIPTION
This change lets folks connect using stock noVNC by using the "runner"
username instead of a goval token. This _only_ works if a password is
explicitly provided for both the VNC server and the connection.