### PR TITLE
Add nix build files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,12 +4,7 @@ rustPlatform.buildRustPackage rec {
   pname = "rfbproxy";
   version = "0.1.1-90b68e1";
 
-  src = fetchFromGitHub {
-    owner = "replit";
-    repo = "rfbproxy";
-    rev = "v${version}";
-    sha256 = "0v33xmqv7fcaq1spiq7mvqpsx47r6ghgsbv4yhcghalxmy7cb2gc";
-  };
+  src = ./.;
 
   cargoSha256 = "1djk818q08lqaz97qqp0wxfx34dvq91sjfnwkz3qq61191j1gp8w";
 

--- a/default.nix
+++ b/default.nix
@@ -1,19 +1,17 @@
-{ lib, rustPlatform, fetchFromGitHub, openssl, stdenv, libpulseaudio, pkg-config, protobuf, lame, libopus, git, runCommand }:
+{ lib, rustPlatform, fetchFromGitHub, openssl, stdenv, libpulseaudio, pkg-config, protobuf, lame, libopus, git, runCommand, copyPathToStore }:
 
 let
-    gitSrc = builtins.filterSource
-               (path: type: true)
-               ./.;
+    src = copyPathToStore ./.;
+    revision = runCommand "get-rev" {
+        nativeBuildInputs = [ git ];
+        dummy = builtins.currentTime;
+    } "GIT_DIR=${src}/.git git rev-parse --short HEAD | tr -d '\n' > $out";
 in
 rustPlatform.buildRustPackage rec {
   pname = "rfbproxy";
-  revision = runCommand "get-rev" {
-      nativeBuildInputs = [ git ];
-      dummy = builtins.currentTime;
-  } "GIT_DIR=${gitSrc}/.git git rev-parse --short HEAD | tr -d '\n' > $out";
   version = builtins.readFile revision;
 
-  src = ./.;
+  inherit src;
 
   cargoSha256 = "1djk818q08lqaz97qqp0wxfx34dvq91sjfnwkz3qq61191j1gp8w";
 

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,22 @@
-{ lib, rustPlatform, fetchFromGitHub, openssl, stdenv, libpulseaudio, pkg-config, protobuf, lame, libopus, git, runCommand, copyPathToStore }:
-
+{ pkgs ? import <nixpkgs>{} } :
+let
+    inherit(pkgs)
+        rustPlatform
+        openssl
+        libpulseaudio
+        pkg-config
+        protobuf
+        lame
+        libopus
+        git
+        runCommand
+        copyPathToStore;
+in
 let
     src = copyPathToStore ./.;
     revision = runCommand "get-rev" {
         nativeBuildInputs = [ git ];
+        # impure, do every time, see https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgitlocal/default.nix#L9
         dummy = builtins.currentTime;
     } "GIT_DIR=${src}/.git git rev-parse --short HEAD | tr -d '\n' > $out";
 in

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,17 @@
-{ lib, rustPlatform, fetchFromGitHub, openssl, stdenv, libpulseaudio, pkg-config, protobuf, lame, libopus }:
+{ lib, rustPlatform, fetchFromGitHub, openssl, stdenv, libpulseaudio, pkg-config, protobuf, lame, libopus, git, runCommand }:
 
+let
+    gitSrc = builtins.filterSource
+               (path: type: true)
+               ./.;
+in
 rustPlatform.buildRustPackage rec {
   pname = "rfbproxy";
-  version = "0.1.1-90b68e1";
+  revision = runCommand "get-rev" {
+      nativeBuildInputs = [ git ];
+      dummy = builtins.currentTime;
+  } "GIT_DIR=${gitSrc}/.git git rev-parse --short HEAD | tr -d '\n' > $out";
+  version = builtins.readFile revision;
 
   src = ./.;
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchFromGitHub, openssl, stdenv, libpulseaudio, pkg-config, protobuf, lame, libopus }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rfbproxy";
+  version = "0.1.1-90b68e1";
+
+  src = fetchFromGitHub {
+    owner = "replit";
+    repo = "rfbproxy";
+    rev = "v${version}";
+    sha256 = "0v33xmqv7fcaq1spiq7mvqpsx47r6ghgsbv4yhcghalxmy7cb2gc";
+  };
+
+  cargoSha256 = "1djk818q08lqaz97qqp0wxfx34dvq91sjfnwkz3qq61191j1gp8w";
+
+  buildInputs = [ openssl libpulseaudio protobuf lame libopus ];
+  nativeBuildInputs = [ pkg-config ];
+
+  # needed for internal protobuf c wrapper library
+  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC_INCLUDE = "${protobuf}/include";
+}


### PR DESCRIPTION
This PR adds the files from https://github.com/replit/nixpkgs-replit/tree/main/pkgs/rfbproxy directly to rfbproxy to reduce the number of repositories we have to update to push changes.