### PR TITLE
Allow passing a version arg to bypass the dynamic versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           components: clippy
 
       - name: Install dependencies
-        run: sudo apt-get install -y libpulse-dev libopus-dev libmp3lame-dev
+        run: sudo apt-get update && sudo apt-get install -y libpulse-dev libopus-dev libmp3lame-dev
 
       - name: build
         run: cargo build

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /pulse/
 test.py
 *.log
+.idea

--- a/src/audio/mp3.rs
+++ b/src/audio/mp3.rs
@@ -40,7 +40,7 @@ pub struct Mp3Encoder {
 impl Mp3Encoder {
     pub fn new(channels: u8, kbps: u16) -> Result<Mp3Encoder> {
         let ctx = unsafe { lame_sys::lame_init() };
-        if ctx == std::ptr::null_mut() {
+        if ctx.is_null() {
             bail!("could not initialize the lame library");
         }
         check_err(unsafe { lame_sys::lame_set_num_channels(ctx, channels as i32) })


### PR DESCRIPTION
This added parameter will override the dynamic versioning system if the .git folder is missing. This is very useful when fetching this repo as a tarbar rather than as a clone with tools like niv or through other derivations.