### PR TITLE
Allow graceful response of HTTP requests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -368,8 +368,14 @@ async fn main() -> Result<()> {
                     const PROTOCOL_HEADER: &str = "Sec-WebSocket-Protocol";
                     if let Some(val) = request.headers().get(PROTOCOL_HEADER) {
                         response.headers_mut().insert(PROTOCOL_HEADER, val.clone());
+                        Ok(response)
+                    } else {
+                        let resp = tungstenite::handshake::server::Response::builder()
+                            .status(http::StatusCode::BAD_REQUEST)
+                            .body(Some("This is a WebSocket server".into()))
+                            .unwrap();
+                        Err(resp)
                     }
-                    Ok(response)
                 },
             )
             .await


### PR DESCRIPTION
Previously if a raw HTTP request was made, it would be rejected by the
handshake machinery and close the connection abruptly.

This change makes it such that HTTP requests will be rejected with an
HTTP 400 Bad Request, which is a lot nicer.

As seen on https://github.com/snapview/tungstenite-rs/blob/550cc49cc61450cd9633ddd251b356de9945ea81/examples/callback-error.rs